### PR TITLE
argparse configuration file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,6 +48,10 @@ The easiest way to make use of yaclifw is by cloning the
 repository and modifying the main.py method to include
 your own commands.
 
+Note that yaclifw uses a wrapped version of argparse to allow argument to
+be specified at the command line or in a configuration file, however not
+all argparse functions are supported.
+
 Contributing
 ------------
 

--- a/test/unit/test_argparseconfig.py
+++ b/test/unit/test_argparseconfig.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+#
+# Copyright (C) 2014 University of Dundee & Open Microscopy Environment
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+import pytest
+
+import argparse
+from ConfigParser import SafeConfigParser, NoSectionError
+from omego import argparseconfig
+
+
+class TestArgparseConfigParser(object):
+
+    def setup_method(self, method):
+        cp = SafeConfigParser()
+
+        cp.add_section('main')
+        cp.set('main', 'int', '1')
+
+        cp.add_section('subparser1')
+        cp.set('subparser1', 'string', 'a string')
+
+        cp.add_section('subgroup1')
+        cp.set('subgroup1', 'float', '2.3')
+
+        self.cp = cp
+
+    def assert_args_equal(self, refdict, args):
+        """
+        Asserts that the list of public attributes of an object and the values
+        of those attributes are equal to refdict
+        """
+        assert refdict == args.__dict__
+
+    def assert_args_contains(self, refdict, obj):
+        """
+        Asserts that the list of public attributes of an object and the values
+        of those attributes includes those in refdict
+        """
+        for k, v in refdict.iteritems():
+            assert hasattr(obj, k)
+            assert getattr(obj, k) == v
+
+    @pytest.mark.parametrize('mode', ['noargs', 'args'])
+    @pytest.mark.parametrize('add_to_self', [True, False])
+    def test_add_and_parse_config_files(self, tmpdir, mode, add_to_self):
+        cfg1txt = [
+            '[main]',
+            'a = 1',
+            '[subgroup]',
+            'b = 2',
+        ]
+        cfg2txt = [
+            '[subgroup]',
+            'b = 3'
+        ]
+
+        cfg1 = tmpdir.join('f1.cfg')
+        cfg1.write('\n'.join(cfg1txt))
+        cfg2 = tmpdir.join('f2.cfg')
+        cfg2.write('\n'.join(cfg2txt))
+
+        argv1 = ['-c', str(cfg1), '--conffile', str(cfg2)]
+        if mode == 'noargs':
+            argv2 = []
+            expected2 = {'a': 1, 'b': None}
+        else:
+            argv2 = ['-a', '10', '-b', '20']
+            expected2 = {'a': 10, 'b': 20}
+        if add_to_self:
+            expected2['conffile'] = []
+        argv = argv1 + argv2
+
+        parser = argparseconfig.ArgparseConfigParser(add_help=False)
+        parsed, remaining, config, cfgparser = \
+            parser.add_and_parse_config_files(
+                '-c', '--conffile', args=argv, config_section='main',
+                add_to_self=add_to_self)
+
+        assert parser.config_parser == config
+        self.assert_args_equal({'conffile': [str(cfg1), str(cfg2)]}, parsed)
+        assert remaining == argv2
+        assert config.sections() == ['main', 'subgroup']
+        assert dict(config.items('main')) == {'a': '1'}
+        assert dict(config.items('subgroup')) == {'b': '3'}
+
+        parser.add_argument('-a', type=int)
+        parser.add_argument('-b', type=int)
+        parsed2 = parser.parse_args(remaining)
+
+        self.assert_args_equal(expected2, parsed2)
+
+    @pytest.mark.parametrize('config', ['match', 'nomatch', 'none'])
+    @pytest.mark.parametrize('default', [None, 1])
+    def test_set_action_default_from_config(self, config, default):
+        action = argparse.Action('--test', 'test', default=default)
+
+        if config == 'match':
+            cd = {'test': 2}
+            expected = {'default': 2}
+        elif config == 'nomatch':
+            cd = {'other': 3}
+            expected = {'default': default}
+        else:
+            cd = None
+            expected = {'default': default}
+        argparseconfig.set_action_default_from_config(action, cd)
+
+        self.assert_args_contains(expected, action)
+
+    @pytest.mark.parametrize('config', ['dict', 'parser'])
+    @pytest.mark.parametrize('mode', ['noargs', 'args'])
+    def test_subgroup(self, config, mode):
+        if config == 'dict':
+            acpargs = {'config_dict': dict(self.cp.items('main'))}
+            subgargs = {'config_dict': dict(self.cp.items('subgroup1'))}
+        else:
+            acpargs = {'config_parser': self.cp, 'config_section': 'main'}
+            subgargs = {'config_section': 'subgroup1'}
+
+        parser = argparseconfig.ArgparseConfigParser(**acpargs)
+        parser.add_argument('--int', type=int)
+
+        subgroup1 = parser.add_argument_group('subgroup1', **subgargs)
+        subgroup1.add_argument('--float', type=float)
+
+        if mode == 'noargs':
+            argv = []
+            expected = {'int': 1, 'float': 2.3}
+        elif mode == 'args':
+            argv = ['--int', '2', '--float', '4.5']
+            expected = {'int': 2, 'float': 4.5}
+
+        args = parser.parse_args(argv)
+        self.assert_args_equal(expected, args)
+
+    @pytest.mark.parametrize('config', ['dict', 'parser'])
+    @pytest.mark.parametrize('mode', ['noargs', 'nosubargs', 'args'])
+    def test_subparser(self, config, mode):
+        if config == 'dict':
+            acpargs = {'config_dict': dict(self.cp.items('main'))}
+            subpargs = {'config_dict': dict(self.cp.items('subparser1'))}
+            subgargs = {'config_dict': dict(self.cp.items('subgroup1'))}
+        else:
+            acpargs = {'config_parser': self.cp, 'config_section': 'main'}
+            subpargs = {'config_section': 'subparser1'}
+            subgargs = {'config_section': 'subgroup1'}
+
+        parser = argparseconfig.ArgparseConfigParser(**acpargs)
+        parser.add_argument('--int', type=int)
+
+        subparsers = parser.add_subparsers()
+        subparser1 = subparsers.add_parser('subparser1', **subpargs)
+        subparser1.add_argument('--string')
+
+        subgroup1 = subparser1.add_argument_group('subgroup1', **subgargs)
+        subgroup1.add_argument('--float', type=float)
+
+        if mode == 'noargs':
+            argv = []
+            # argparse calls system.exit on failure
+            expected = SystemExit
+        elif mode == 'nosubargs':
+            argv = ['--int', '2', 'subparser1']
+            expected = {'int': 2, 'string': 'a string', 'float': 2.3}
+        elif mode == 'args':
+            argv = ['--int', '2', 'subparser1', '--string', 'zzz',
+                    '--float', '4.5']
+            expected = {'int': 2, 'string': 'zzz', 'float': 4.5}
+
+        if expected == SystemExit:
+            with pytest.raises(expected):
+                args = parser.parse_args(argv)
+        else:
+            args = parser.parse_args(argv)
+            self.assert_args_equal(expected, args)
+
+    @pytest.mark.parametrize('ignore_missing', [True, False])
+    @pytest.mark.parametrize('missing', [True, False])
+    def test_get_set_config(self, ignore_missing, missing):
+        acpargs = {'config_parser': self.cp, 'config_section': 'main'}
+        if not ignore_missing:
+            acpargs['ignore_missing'] = False
+        if missing:
+            acpargs['config_section'] = 'missing'
+
+        if ignore_missing or not missing:
+            parser = argparseconfig.ArgparseConfigParser(**acpargs)
+            if missing:
+                assert parser.config_dict == {}
+            else:
+                assert parser.config_dict == {'int': '1'}
+        else:
+            if missing:
+                with pytest.raises(NoSectionError):
+                    parser = argparseconfig.ArgparseConfigParser(**acpargs)
+            else:
+                parser = argparseconfig.ArgparseConfigParser(**acpargs)
+                assert parser.config_dict == {'int': '1'}

--- a/test/unit/test_argparseconfig.py
+++ b/test/unit/test_argparseconfig.py
@@ -23,7 +23,7 @@ import pytest
 
 import argparse
 from ConfigParser import SafeConfigParser, NoSectionError
-from omego import argparseconfig
+from yaclifw import argparseconfig
 
 
 class TestArgparseConfigParser(object):

--- a/test/unit/test_argparseconfig.py
+++ b/test/unit/test_argparseconfig.py
@@ -145,6 +145,35 @@ class TestArgparseConfigParser(object):
 
         self.assert_args_equal(expected, parsed2)
 
+    def test_merge_config_sections(self, tmpdir):
+        cfg1txt = [
+            '[main]',
+            'a = 1',
+            'b = 2',
+            '[section1]',
+            'a = 10',
+            '[section2]',
+            'b = 20',
+        ]
+
+        cfg1 = tmpdir.join('f1.cfg')
+        cfg1.write('\n'.join(cfg1txt))
+
+        argv = ['-c', str(cfg1)]
+        expected = {'a': 1, 'b': 20}
+
+        parser = argparseconfig.ArgparseConfigParser(add_help=False)
+        parsed, remaining, config, cfgparser = \
+            parser.add_and_parse_config_files(
+                '-c', '--conffile', args=argv,
+                config_section=['main', 'section2'])
+
+        parser.add_argument('-a', type=int)
+        parser.add_argument('-b', type=int)
+        parsed2 = parser.parse_args(remaining)
+
+        self.assert_args_equal(expected, parsed2)
+
     @pytest.mark.parametrize('config', ['match', 'nomatch', 'none'])
     @pytest.mark.parametrize('default', [None, 1])
     def test_set_action_default_from_config(self, config, default):

--- a/test/unit/test_argparseconfig.py
+++ b/test/unit/test_argparseconfig.py
@@ -123,7 +123,8 @@ class TestArgparseConfigParser(object):
 
         if mode == 'noargs':
             argv = []
-            expected = {'a': False, 'b': True, 'd': False, 'e': True, 'vs': None}
+            expected = {
+                'a': False, 'b': True, 'd': False, 'e': True, 'vs': None}
         elif mode == 'cmdargs':
             argv = ['-a', '-b', '-d', '-e', '-vv']
             expected = {'a': True, 'b': False, 'd': True, 'e': False, 'vs': 2}

--- a/yaclifw/argparseconfig.py
+++ b/yaclifw/argparseconfig.py
@@ -70,7 +70,6 @@ class ArgumentGroupParser(object):
         Overrides add_argument so that the string values from a configuration
         file can be converted to the required type if specified.
         """
-        has_default = 'default' in kwargs
         action = self.group.add_argument(*args, **kwargs)
         if kwargs.get('action') == 'count':
             setattr(action, 'type', int)
@@ -250,7 +249,6 @@ class ArgparseConfigParser(argparse.ArgumentParser):
         return parsed_args, remaining_args, config, cfgparser
 
     def add_argument(self, *args, **kwargs):
-        has_default = 'default' in kwargs
         action = super(ArgparseConfigParser, self).add_argument(
             *args, **kwargs)
         if kwargs.get('action') == 'count':

--- a/yaclifw/argparseconfig.py
+++ b/yaclifw/argparseconfig.py
@@ -39,8 +39,6 @@ def set_action_default_from_config(action, config_dict):
             default = config_dict[action.dest]
             if action.type:
                 default = action.type(default)
-            print 'Default %s: %s -> %s' % (
-                action.dest, action.default, default)
             action.default = default
         except KeyError:
             pass
@@ -73,7 +71,6 @@ class ArgumentGroupParser(object):
         file can be converted to the required type if specified.
         """
         has_default = 'default' in kwargs
-        print 'ArgumentGroupParser.add_argument', args, kwargs, has_default
         action = self.group.add_argument(*args, **kwargs)
         if kwargs.get('action') == 'count':
             setattr(action, 'type', int)
@@ -254,19 +251,16 @@ class ArgparseConfigParser(argparse.ArgumentParser):
 
     def add_argument(self, *args, **kwargs):
         has_default = 'default' in kwargs
-        print 'ArgparseConfigParser.add_argument', args, kwargs, has_default
         action = super(ArgparseConfigParser, self).add_argument(
             *args, **kwargs)
         if kwargs.get('action') == 'count':
             setattr(action, 'type', int)
         if kwargs.get('action') in ('store_true', 'store_false'):
             setattr(action, 'type', boolconv)
-        print action.type
         set_action_default_from_config(action, self.config_dict)
         return action
 
     def add_argument_group(self, *args, **kwargs):
-        print 'ArgparseConfigParser.add_argument_group', args, kwargs
         group_config_section = kwargs.pop('config_section', None)
         group_config_dict = kwargs.pop('config_dict', None)
 

--- a/yaclifw/argparseconfig.py
+++ b/yaclifw/argparseconfig.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+#
+# Copyright (C) 2014 University of Dundee & Open Microscopy Environment
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""
+A combination of command-line argument parsing using argparse and
+configuration file options using ConfigParser
+"""
+
+import argparse
+import ConfigParser
+
+
+def set_action_default_from_config(action, config_dict):
+    """
+    If config_dict contains a matching key matching action.dest then use this
+    to set the default value of the argparse action object
+    """
+    if config_dict:
+        try:
+            assert action.dest
+            default = config_dict[action.dest]
+            if action.type:
+                default = action.type(default)
+            print 'Default %s: %s -> %s' % (
+                action.dest, action.default, default)
+            action.default = default
+        except KeyError:
+            pass
+
+
+class ArgumentGroupParser(object):
+    """
+    Overrides the add_argument method of the object returned by
+    ArgumentParser.add_argument_group()
+    """
+
+    def __init__(self, group, config_dict):
+        self.group = group
+        self.config_dict = config_dict
+
+    def add_argument(self, *args, **kwargs):
+        """
+        Overrides add_argument so that the string values from a configuration
+        file can be converted to the required type if specified.
+        """
+        has_default = 'default' in kwargs
+        print 'ArgumentGroupParser.add_argument', args, kwargs, has_default
+        action = self.group.add_argument(*args, **kwargs)
+        set_action_default_from_config(action, self.config_dict)
+        return action
+
+    def __getattr__(self, name):
+        return getattr(self.group, name)
+
+
+class ArgparseConfigParser(argparse.ArgumentParser):
+    """
+    An ArgumentParser that uses ConfigParser values as defaults, inspired by
+    http://blog.vwelch.com/2011/04/combining-configparser-and-argparse.html
+
+    Instead of using ArgumentParser.set_defaults() this overrides
+    ArgumentParser.add_argument so that the `type` argument can be used to
+    convert strings from the ConfigParser into the specified type
+
+    Optional keyword arguments:
+      Only one of config_dict or config_parser can be provided
+      config_dict, dict: A dictionary of arguments and default values, for
+        example dict(ConfigParser.items())
+      config_parser, ConfigParser: A ConfigParser object, if specified then
+        config_section should also be given
+      config_section, str: The ConfigParser section name, if not specified
+        then no config values will be used for this parser
+      ignore_missing, bool: If True (default) missing configuration
+        sections will be ignored. If configuration files are optional this
+        must be True.
+
+
+    Overridden methods
+
+    add_argument()
+      Overrides add_argument so that the string values from a configuration
+      file can be converted to the required type if necessary.
+
+    add_argument_group(..., config_dict=dict, config_section=str)
+      Takes an optional set of config file values, one of the following can be
+      specified:
+        config_dict, dict: A dictionary of arguments and default values
+        config_section, str: The ConfigParser section name, a config_parser
+          must have been provided when constructing the ArgparseConfigParser
+
+    add_subparsers()
+      Returns a modified subparsers object that includes a link to the parent
+      config values. This object includes a method addparser().
+
+      addparser()
+        Takes the same optional config arguments as ArgparseConfigParser,
+        except that config_parser from the parent parser will be automatically
+        set if not otherwise provided, so just config_section can be
+        specified.
+
+
+    Additional methods
+
+    add_and_parse_config_files(*optionargs,
+        args=None, config_section=None, add_help=True, add_to_self=False)
+      Looks for config-files, and attempts to parse them. If multiple
+      config-file arguments are passed they will be merged with values from
+      later files overridding earlier ones.
+
+      The configurations will be added to this object. If add_to_self is True
+      then the argument parser will be added to this object, otherwise they
+      will be added to a separate parser.
+
+      Note this will call parse_known_args() to find any config files in the
+      command line arguments. This means if help was requested the parser will
+      exit before all other arguments have been added. To prevent this pass
+      add_help=False to ArgparseConfigParser, and add it after the initial
+      parse to find the config files has been completed.
+
+      optionargs: short and/or long option names for indicating config file
+        arguments
+      args: Optional, array of arguments to be parsed
+      config_section: The name of the section in the config-file to use
+      add_help: Whether to add a help argument
+      return: (parsed_args, remaining_args, config)
+        parsed_args: A Namespace object containing the parsed arguments
+        remaining_args: Array of args which weren't parsed
+        config: The ConfigParser object with all config files combined
+      e.g. add_and_parse_config_files(
+             '-c', '--conffile', ..., config_section='section')
+
+    set_config(config_parser, config_section=None)
+      Sets or changes the config_parser, see above
+
+
+    Examples:
+
+    config = ConfigParser.SafeConfigParser()
+    # config.cfg must contain sections 'main', 'subparser' and 'subgroup'
+    config.read('config.cfg')
+    config_main = config.items('main')
+    config_subparser = config.items('subparser')
+    config_group = config.items('subgroup')
+
+    parser = ArgparseConfigParser(config_dict=dict(config_main))
+    group = parser.add_argument_group('title', config_dict=dict(config_group))
+
+    parser = ArgparseConfigParser(config_parser=config, config_section='main')
+    subparsers = parser.add_subparsers(title='Subparsers')
+    subparser = subparsers.add_parser(
+        'subparser', help='Subparser help', config_section='subparser')
+    group = subparser.add_argument_group('title', config_section='subgroup')
+
+    argv = '-c f1.cfg -c f2.cfg -a 1 -b 1'.split()
+    parser = ArgparseConfigParser(add_help=False)
+    parsed, remaining, config = parser.add_and_parse_config_files(
+        '-c', '--conffile', args=argv, config_section='section', add_help=True)
+    # c1.cfg and c2.cfg will be read and the required section used to set the
+    # defaults for subsequent add_argument() calls
+    parser.add_argument('-a', help='Help for a')
+    args = parser.parse_args(remaining)
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.config_dict = kwargs.pop('config_dict', None)
+        self.config_parser = kwargs.pop('config_parser', None)
+        config_section = kwargs.pop('config_section', None)
+        self.ignore_missing = bool(kwargs.pop('ignore_missing', True))
+
+        if self.config_dict and self.config_parser:
+            raise Exception('Invalid combination of arguments')
+        if self.config_parser:
+            self.config_dict = self.get_config_section(config_section)
+
+        super(ArgparseConfigParser, self).__init__(*args, **kwargs)
+        self.subparsers = None
+
+    def add_and_parse_config_files(self, *optionargs, **kwargs):
+        # Must disable help, otherwise parse_args will exit prematurely before
+        # the subparsers have been added. Unfortunately this means the config
+        # files will always be read even if help is specified
+
+        args = kwargs.pop('args', None)
+        config_section = kwargs.pop('config_section', None)
+        add_help = kwargs.pop('add_help', True)
+        add_to_self = kwargs.pop('add_to_self', False)
+
+        if add_to_self:
+            cfgparser = self
+        else:
+            cfgparser = ArgparseConfigParser(add_help=False)
+        cfgparser.add_argument(
+            *optionargs, action='append', default=[],
+            help='Configuration file (can be repeated)', metavar='FILE.cfg')
+
+        parsed_args, remaining_args = cfgparser.parse_known_args(args)
+        config = ConfigParser.SafeConfigParser()
+        # TODO: Read defaults in from a file
+        # config.readfp(open('defaults.cfg'))
+        if parsed_args.conffile:
+            files_read = config.read(parsed_args.conffile)
+        else:
+            files_read = []
+        unread = set(parsed_args.conffile) - set(files_read)
+        if unread:
+            raise Exception(
+                'Failed to read configuration file(s): %s' % ' '.join(unread))
+
+        if add_help:
+            cfgparser.add_argument(
+                '-h', '--help', action='help', default=argparse.SUPPRESS,
+                help='show this help message and exit')
+
+        self.set_config(config, config_section)
+        return parsed_args, remaining_args, config, cfgparser
+
+    def add_argument(self, *args, **kwargs):
+        has_default = 'default' in kwargs
+        print 'ArgparseConfigParser.add_argument', args, kwargs, has_default
+        action = super(ArgparseConfigParser, self).add_argument(
+            *args, **kwargs)
+        set_action_default_from_config(action, self.config_dict)
+        return action
+
+    def add_argument_group(self, *args, **kwargs):
+        print 'ArgparseConfigParser.add_argument_group', args, kwargs
+        group_config_section = kwargs.pop('config_section', None)
+        group_config_dict = kwargs.pop('config_dict', None)
+
+        if group_config_section and group_config_dict is not None:
+            raise Exception('Invalid combination of arguments')
+
+        if group_config_section is not None:
+            if not self.config_parser:
+                raise Exception('No ConfigParser was provided')
+            group_config_dict = self.get_config_section(group_config_section)
+        elif group_config_dict is None:
+            group_config_dict = self.config_dict
+        # Allow {} to indicate no config values
+
+        group = super(ArgparseConfigParser, self).add_argument_group(
+            *args, **kwargs)
+        return ArgumentGroupParser(group, group_config_dict)
+
+    def add_subparsers(self, *args, **kwargs):
+        class SubParsers:
+            def __init__(self, parent):
+                self.parent = parent
+
+            def add_parser(self, *args, **kwargs):
+                kwargs.setdefault('config_parser', self.parent.config_parser)
+                return self.parent.subparsers.add_parser(*args, **kwargs)
+
+        self.subparsers = super(ArgparseConfigParser, self).add_subparsers(
+            *args, **kwargs)
+        return SubParsers(self)
+
+    def set_config(self, config_parser, config_section=None):
+        self.config_parser = config_parser
+        self.config_dict = self.get_config_section(config_section)
+
+    def get_config_section(self, section):
+        if section is None:
+            return {}
+            # raise Exception('No ConfigParser section name provided')
+        try:
+            return dict(self.config_parser.items(section))
+        except ConfigParser.NoSectionError:
+            if self.ignore_missing:
+                return {}
+            raise

--- a/yaclifw/argparseconfig.py
+++ b/yaclifw/argparseconfig.py
@@ -46,6 +46,17 @@ def set_action_default_from_config(action, config_dict):
             pass
 
 
+def boolconv(s):
+    """
+    Converts a string to a bool
+    """
+    if s.lower() in ('0', 'false'):
+        return False
+    if s.lower() in ('1', 'true'):
+        return True
+    raise Exception('Invalid boolean string: %s' % s)
+
+
 class ArgumentGroupParser(object):
     """
     Overrides the add_argument method of the object returned by
@@ -64,6 +75,10 @@ class ArgumentGroupParser(object):
         has_default = 'default' in kwargs
         print 'ArgumentGroupParser.add_argument', args, kwargs, has_default
         action = self.group.add_argument(*args, **kwargs)
+        if kwargs.get('action') == 'count':
+            setattr(action, 'type', int)
+        if kwargs.get('action') in ('store_true', 'store_false'):
+            setattr(action, 'type', boolconv)
         set_action_default_from_config(action, self.config_dict)
         return action
 
@@ -97,7 +112,9 @@ class ArgparseConfigParser(argparse.ArgumentParser):
 
     add_argument()
       Overrides add_argument so that the string values from a configuration
-      file can be converted to the required type if necessary.
+      file can be converted to the required type if necessary. Also checks
+      for a limited set of known action types to infer the required type
+      (count:int, store_true:bool, store_false:bool)
 
     add_argument_group(..., config_dict=dict, config_section=str)
       Takes an optional set of config file values, one of the following can be
@@ -237,6 +254,11 @@ class ArgparseConfigParser(argparse.ArgumentParser):
         print 'ArgparseConfigParser.add_argument', args, kwargs, has_default
         action = super(ArgparseConfigParser, self).add_argument(
             *args, **kwargs)
+        if kwargs.get('action') == 'count':
+            setattr(action, 'type', int)
+        if kwargs.get('action') in ('store_true', 'store_false'):
+            setattr(action, 'type', boolconv)
+        print action.type
         set_action_default_from_config(action, self.config_dict)
         return action
 

--- a/yaclifw/example.py
+++ b/yaclifw/example.py
@@ -15,8 +15,8 @@ class ExampleCommand(Command):
 
     NAME = "example"
 
-    def __init__(self, sub_parsers):
-        super(ExampleCommand, self).__init__(sub_parsers)
+    def __init__(self, sub_parsers, parents):
+        super(ExampleCommand, self).__init__(sub_parsers, parents)
 
         self.parser.add_argument("-n", "--dry-run", action="store_true")
 

--- a/yaclifw/framework.py
+++ b/yaclifw/framework.py
@@ -81,16 +81,19 @@ class Command(object):
 
     NAME = "abstract"
 
-    def __init__(self, sub_parsers, parents=None, set_defaults=True):
+    def __init__(self, sub_parsers, parents=None, config_section=None,
+                 set_defaults=True):
         self.log = logging.getLogger("%s.%s" % (FRAMEWORK_NAME, self.NAME))
         self.log_level = DEBUG_LEVEL
 
         help = self.__doc__
         if help:
             help = help.lstrip()
+        if config_section is None:
+            config_section = self.NAME
         self.parser = sub_parsers.add_parser(
-            self.NAME, help=help, description=help, config_section=self.NAME,
-            parents=parents)
+            self.NAME, help=help, description=help,
+            config_section=config_section, parents=parents)
         if set_defaults:
             self.parser.set_defaults(func=self.__call__)
 

--- a/yaclifw/framework.py
+++ b/yaclifw/framework.py
@@ -89,6 +89,8 @@ class Command(object):
         help = self.__doc__
         if help:
             help = help.lstrip()
+        if parents is None:
+            parents = []
         if config_section is None:
             config_section = self.NAME
         self.parser = sub_parsers.add_parser(
@@ -213,7 +215,11 @@ def main(fw_name, args=None, items=None, parse_config_files=None):
             continue
         if MyCommand.NAME == "abstract":
             continue
-        MyCommand(sub_parsers, parents)
+        try:
+            MyCommand(sub_parsers, parents)
+        except TypeError:
+            # Backwards compatible with yaclifw <= 0.1.2
+            MyCommand(sub_parsers)
 
     ns = yaclifw_parser.parse_args(args)
     ns.func(ns)

--- a/yaclifw/framework.py
+++ b/yaclifw/framework.py
@@ -117,9 +117,10 @@ class Command(object):
         self.dbg = self.log.debug
 
 
-def parsers(parse_config_files=None):
+def parsers(args=None, parse_config_files=None):
     """
     Create the base command line arguments parser
+    args: Command line argument to parse
     parse_config_files: A list of option names to indicate config-files
       containing command line option arguments, for example
       ['-c', '--conffile']. If provided a first pass will be done to read
@@ -160,7 +161,8 @@ def parsers(parse_config_files=None):
     if parse_config_files:
         parsed, remaining, config, cfgparser = \
             yaclifw_parser.add_and_parse_config_files(
-                *parse_config_files, config_section='main', add_help=False)
+                *parse_config_files, args=args, config_section='main',
+                add_help=False)
         parents.append(cfgparser)
 
     sub_parsers = yaclifw_parser.add_subparsers(title="Subcommands")
@@ -199,7 +201,7 @@ def main(fw_name, args=None, items=None, parse_config_files=None):
     if items is None:
         items = globals().items()
 
-    yaclifw_parser, sub_parsers, parents = parsers(parse_config_files)
+    yaclifw_parser, sub_parsers, parents = parsers(args, parse_config_files)
 
     for name, MyCommand in sorted(items):
         if not isinstance(MyCommand, type):

--- a/yaclifw/framework.py
+++ b/yaclifw/framework.py
@@ -42,6 +42,7 @@ DEBUG_LEVEL = logging.INFO
 argparse_loaded = True
 try:
     import argparse
+    import argparseconfig
 except ImportError:
     print >> sys.stderr, \
         "Module argparse missing. Install via 'pip install argparse'"
@@ -80,15 +81,16 @@ class Command(object):
 
     NAME = "abstract"
 
-    def __init__(self, sub_parsers, set_defaults=True):
+    def __init__(self, sub_parsers, parents=None, set_defaults=True):
         self.log = logging.getLogger("%s.%s" % (FRAMEWORK_NAME, self.NAME))
         self.log_level = DEBUG_LEVEL
 
         help = self.__doc__
         if help:
             help = help.lstrip()
-        self.parser = sub_parsers.add_parser(self.NAME,
-                                             help=help, description=help)
+        self.parser = sub_parsers.add_parser(
+            self.NAME, help=help, description=help, config_section=self.NAME,
+            parents=parents)
         if set_defaults:
             self.parser.set_defaults(func=self.__call__)
 
@@ -115,7 +117,14 @@ class Command(object):
         self.dbg = self.log.debug
 
 
-def parsers():
+def parsers(parse_config_files=None):
+    """
+    Create the base command line arguments parser
+    parse_config_files: A list of option names to indicate config-files
+      containing command line option arguments, for example
+      ['-c', '--conffile']. If provided a first pass will be done to read
+      the config files and set the default values
+    """
 
     class HelpFormatter(argparse.RawTextHelpFormatter):
         """
@@ -143,15 +152,23 @@ def parsers():
                 argparse.RawTextHelpFormatter._Section.__init__(
                     self, formatter, parent, heading)
 
-    yaclifw_parser = argparse.ArgumentParser(
+    yaclifw_parser = argparseconfig.ArgparseConfigParser(
         description='omego - installation and administration tool',
         formatter_class=HelpFormatter)
+
+    parents = []
+    if parse_config_files:
+        parsed, remaining, config, cfgparser = \
+            yaclifw_parser.add_and_parse_config_files(
+                *parse_config_files, config_section='main', add_help=False)
+        parents.append(cfgparser)
+
     sub_parsers = yaclifw_parser.add_subparsers(title="Subcommands")
 
-    return yaclifw_parser, sub_parsers
+    return yaclifw_parser, sub_parsers, parents
 
 
-def main(fw_name, args=None, items=None):
+def main(fw_name, args=None, items=None, parse_config_files=None):
     """
     Reusable entry point. Arguments are parsed
     via the argparse-subcommands configured via
@@ -182,7 +199,7 @@ def main(fw_name, args=None, items=None):
     if items is None:
         items = globals().items()
 
-    yaclifw_parser, sub_parsers = parsers()
+    yaclifw_parser, sub_parsers, parents = parsers(parse_config_files)
 
     for name, MyCommand in sorted(items):
         if not isinstance(MyCommand, type):
@@ -191,7 +208,7 @@ def main(fw_name, args=None, items=None):
             continue
         if MyCommand.NAME == "abstract":
             continue
-        MyCommand(sub_parsers)
+        MyCommand(sub_parsers, parents)
 
     ns = yaclifw_parser.parse_args(args)
     ns.func(ns)

--- a/yaclifw/main.py
+++ b/yaclifw/main.py
@@ -43,7 +43,7 @@ def entry_point(items=tuple()):
             from version import Version
             items = [(ExampleCommand.NAME, ExampleCommand),
                      (Version.NAME, Version)]
-        main("yaclifw", items=items)
+        main("yaclifw", items=items, parse_config_files=['-c', '--conffile'])
     except Stop, stop:
         print stop,
         sys.exit(stop.rc)

--- a/yaclifw/version.py
+++ b/yaclifw/version.py
@@ -140,8 +140,8 @@ class Version(Command):
     NAME = "version"
     FILE = module_file
 
-    def __init__(self, sub_parsers):
-        super(Version, self).__init__(sub_parsers)
+    def __init__(self, sub_parsers, parents):
+        super(Version, self).__init__(sub_parsers, parents)
         # No token args
 
     def __call__(self, args):


### PR DESCRIPTION
This is an attempt to let a configuration file provide defaults for argparse comand line options, using Python's `ConfigFileParser`

Main points:
* Config file values are automatically cast if a `type` is specified in `add_argument`
  * Limited support for the `action` parameter of `add_argument`: `store_true`/`store_false`/`count` will result in a config value being automatically cast to `bool`/`bool`/`int`, other actions are untested
* I've tried to avoid referencing any private underscore classes from `argparse` (though this makes things more complicated)
* Parsing has to be done in two steps:
  1. Look for any config file arguments, and parse those files
  2. Parse the remaining arguments
* Parsers/subparsers can reference one or more sections from ConfigFileParser
  * Multiple sections can be specified and merged (e.g. you could have a defaults section overriden later)
* Shouldn't require significant changes to users of this class.
* Configuration keys are named after the argparse `dest` value (e.g. `dry_run` not `dry-run`)
* Note added to README.rst

Corresponding omego PR/config: ome/omego#47
See also ome/omego#41