### PR TITLE
Modify setup.py usage in Python testing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,7 @@ Unit tests
 
 Unit tests are stored under the `test/unit` folder and can be run by calling::
 
-  python setup.py test -s test/unit
+  python setup.py test -t test/unit
 
 Unit tests are also run by the Travis_ build on every Pull Request opened
 against the main repository.

--- a/setup.py
+++ b/setup.py
@@ -31,17 +31,18 @@ import sys
 
 
 class PyTest(TestCommand):
-    user_options = TestCommand.user_options + \
-        [('test-pythonpath=', 'p', "prepend 'pythonpath' to PYTHONPATH"),
-         ('test-string=', 'k', "only run tests including 'string'"),
-         ('test-marker=', 'm', "only run tests including 'marker'"),
-         ('test-path=', 's', "base dir for test collection"),
-         ('test-failfast', 'x', "Exit on first error"),
-         ('test-verbose', 'v', "more verbose output"),
-         ('test-quiet', 'q', "less verbose output"),
-         ('junitxml=', None, "create junit-xml style report file at 'path'"),
-         ('pdb', None, "fallback to pdb on error"),
-         ]
+    user_options = [
+        ('test-path=', 't', "base dir for test collection"),
+        ('test-pythonpath=', 'p', "prepend 'pythonpath' to PYTHONPATH"),
+        ('test-string=', 'k', "only run tests including 'string'"),
+        ('test-marker=', 'm', "only run tests including 'marker'"),
+        ('test-no-capture', 's', "don't suppress test output"),
+        ('test-failfast', 'x', "Exit on first error"),
+        ('test-verbose', 'v', "more verbose output"),
+        ('test-quiet', 'q', "less verbose output"),
+        ('junitxml=', None, "create junit-xml style report file at 'path'"),
+        ('pdb', None, "fallback to pdb on error"),
+        ]
 
     def initialize_options(self):
         TestCommand.initialize_options(self)
@@ -52,6 +53,7 @@ class PyTest(TestCommand):
         self.test_failfast = False
         self.test_quiet = False
         self.test_verbose = False
+        self.test_no_capture = False
         self.junitxml = None
         self.pdb = False
 
@@ -64,6 +66,8 @@ class PyTest(TestCommand):
             self.test_args.extend(['-m', self.test_marker])
         if self.test_failfast:
             self.test_args.extend(['-x'])
+        if self.test_no_capture:
+            self.test_args.extend(['-s'])
         if self.test_verbose:
             self.test_args.extend(['-v'])
         if self.test_quiet:

--- a/travis-build
+++ b/travis-build
@@ -1,6 +1,6 @@
 set -e
 flake8 -v setup.py test yaclifw
-python setup.py test -s test/unit -v
+python setup.py test -t test/unit -v
 python setup.py sdist install
 pip install dist/*.tar.gz
 yaclifw -h


### PR DESCRIPTION
The following commands should work:

    ./setup.py test -t <path to tests> should run a folder of tests
    ./setup.py test -t <path to tests> -s should run a folder of tests and output any stdout with the tests to the console.
