### PR TITLE
Update Makefile for twine releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 release:
+ifndef VERSION
+	$(error VERSION is undefined)
+endif
 	git describe --exact
-	python setup.py sdist upload --sign
+	python setup.py sdist
+	twine upload dist/yaclifw-$(VERSION).tar.gz
 
 clean:
 	rm -rf build dist yaclifw.egg-info *.pyc


### PR DESCRIPTION
Minor tweak to the release `Makefile` target after gh-9